### PR TITLE
Fix LilVessel accepting ore dictionary ectoplasm

### DIFF
--- a/src/main/java/com/unoriginal/beastslayer/entity/Entities/EntityLilVessel.java
+++ b/src/main/java/com/unoriginal/beastslayer/entity/Entities/EntityLilVessel.java
@@ -232,7 +232,7 @@ public class EntityLilVessel extends EntityTameable implements IRangedAttackMob{
                 }
                 this.setAttackTarget(null);
             }
-            if((itemstack.getItem() == ModItems.ECTOPLASM || OreDictionary.getOres("ectoplasm").contains(itemstack)) && this.getHealth() < this.getMaxHealth()){
+            if((itemstack.getItem() == ModItems.ECTOPLASM || OreDictionary.containsMatch(false, OreDictionary.getOres("ectoplasm"), itemstack)) && this.getHealth() < this.getMaxHealth()){
                 if(!player.capabilities.isCreativeMode) {
                     itemstack.shrink(1);
                 }


### PR DESCRIPTION
The previous implementation did not work.

Edit: https://github.com/Un-Original1/BeastSlayer/commit/34ab05e8fa9143f1a647c68a4baf38aef095828e works